### PR TITLE
Add Bounty Manager to the "Built with PAPI" list

### DIFF
--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -139,6 +139,10 @@ export default defineConfig({
           text: "ParaSpell XCM SDK",
           link: "https://paraspell.xyz/",
         },
+        {
+          text: "Bounty Manager",
+          link: "https://github.com/galaniprojects/Polkadot-Bounty-Manager",
+        },
       ],
     },
   ],


### PR DESCRIPTION
Hi folks!

We would like to add our Bounty Manager to the list of projects using PAPI, what do you think?

Thanks for PAPI by the way!

Kind regards,
Bounty Manager team