### PR TITLE
Update `watchEntries` docs

### DIFF
--- a/docs/pages/typed/queries.md
+++ b/docs/pages/typed/queries.md
@@ -91,8 +91,8 @@ typedApi.query.Pallet.Query.getEntries(arg1, arg2, { at: "0x12345678" }) // 2/3 
 `getEntries` returns as well the key arguments for every entry found. There are some storage entries whose arguments cannot be inferred directly from the key, because the arguments are hashed to compute the key. Therefore, only in these cases, `keyArgs` will be the `key` instead of the arguments themselves. The type will be `OpaqueKeyHash`.
 :::
 
-`watchEntries` allows you to watch changes to all entries of a storage map. As in `getEntries`, you can optionally provide a subset of the keys and/or `{at: "best"}` to watch changes to the best block, instead of the default `"finalized"` block. Events will be emitted disregarding if there were (or not) changes to the entries. There is no guarantee that an event will be emitted for every block. The events will contain:
+`watchEntries` allows you to watch the state of all entries in a storage map as changes occur on-chain. As in `getEntries`, you can optionally provide a subset of the keys and/or `{at: "best"}` to watch entries at the best block, instead of the default `"finalized"` block. Events will be emitted disregarding if there were (or not) changes to the entries. There is no guarantee that an event will be emitted for every block. The events will contain:
 
 - `block`: Block hash, block number, and parent block hash; to identify how updated the information is.
-- `deltas`: In case there were any changes since previous event, `upserted` (meaning added or changed) and `deleted` entries. If `deltas` were to be `null`, then no changes happened since the last emission.
+- `deltas`: In case there were any changes to `entries` since the previous event, `upserted` (meaning added or changed) and `deleted` entries. `upserted` always contains all entries in the first event, as `entries` is initially populated. If `deltas` were to be `null`, then no changes happened since the last emission.
 - `entries`: Immutable data-structure with the whole bunch of entries, updated to that block.


### PR DESCRIPTION
I'm submitting this PR after discussion in polkadot-api/polkadot-api#1078.

This is a minor rephrasing to emphasize that `watchEntires` is most appropriate for watching the *live state* of some collection of entries, rather than listening for *changes* to said entries.

For example, consumers of this API running a service intended to *react to some storage changing* (a notification service, trigger some data pipeline, etc.) should know
- each time my service restarts, `upserted` will contain *all* entries (It makes sense why it does, but I think this is non-obvious without stating it explicitly)
- there's (likely) an event they are better off using— `watchEntries` isn't really meant for this design pattern