### PR TITLE
docs: list inkathon as papi user

### DIFF
--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -205,6 +205,10 @@ export default defineConfig({
           text: "Bounty Manager",
           link: "https://github.com/galaniprojects/Polkadot-Bounty-Manager",
         },
+        {
+          text: "inkathon",
+          link: "https://github.com/scio-labs/inkathon",
+        },
       ],
     },
   ],


### PR DESCRIPTION
After an awesome delivery on their [ink!ubator grant](https://github.com/use-inkubator/Grant-Milestone-Delivery/pull/23), inkathon has now upgraded their tooling to use `papi`.

I thought it would be quite nice adding them to the list of apps using papi.